### PR TITLE
Write Version to stderr

### DIFF
--- a/main.go
+++ b/main.go
@@ -35,7 +35,7 @@ func main() {
 	}
 	app.Action = func(c *cli.Context) error {
 
-		fmt.Printf("%s v%s by %s\n\n", CMDNAME, VERSION, AUTHOR)
+		fmt.Fprintf(os.Stderr, "%s v%s by %s\n\n", CMDNAME, VERSION, AUTHOR)
 
 		if configPath == "" {
 			log.Fatalf("You must specifiy a configuration file.\n")


### PR DESCRIPTION
Write the application name and version to stderr instead of stdout so
stdout can be used as the output for the output processor.