### PR TITLE
Allow CSV and JSON Readers and Writers to Use stdin/stdout

### DIFF
--- a/config.go
+++ b/config.go
@@ -12,19 +12,21 @@ import (
 	"strings"
 )
 
+type ConfigMap map[string]interface{}
+
 type InputInfo struct {
 	Type   string
-	Config map[string]interface{}
+	Config ConfigMap
 }
 
 type OutputInfo struct {
 	Type   string
-	Config map[string]interface{}
+	Config ConfigMap
 }
 
 type TransformInfo struct {
 	Type   string
-	Config map[string]interface{}
+	Config ConfigMap
 }
 
 type ProcessInfo struct {


### PR DESCRIPTION
Use stdin for csv and json readers if the path attribute is not defined.

Use stdout for csv and json writers if the path attribute is not defined.

Allows using stdin/stdout in platform-independent way rather than using
`path = "/dev/stdin"`, for example.